### PR TITLE
Add Elastic Search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,17 @@ dep_install:
 install:
 	@cd $(PROJECT_PATH) && dep ensure && go install
 
-run: install
+es:
+	@docker-compose -f "docker-compose.yml" up -d --build
+
+es_logs:
+	@docker-compose logs -f
+
+es_down:
+	@curl -X DELETE http://localhost:9200/_all -H 'cache-control: no-cache'
+	@docker-compose down
+
+run: install es_down es
 	./bin/cerebro
 
 test: install

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	@cd $(PROJECT_PATH) && dep ensure && go install
 
 es:
-	@docker-compose -f "docker-compose.yml" up -d --build
+	@docker-compose -f "docker-compose.yml" up -d --build --scale elasticsearch_data=2
 
 es_logs:
 	@docker-compose logs -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.6'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0
+    container_name: elasticsearch
+    environment:
+      - cluster.name=cerebro-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - esnet
+  elasticsearch2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0
+    container_name: elasticsearch2
+    environment:
+      - cluster.name=cerebro-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "discovery.zen.ping.unicast.hosts=elasticsearch"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata2:/usr/share/elasticsearch/data
+    networks:
+      - esnet
+
+volumes:
+  esdata1:
+    driver: local
+  esdata2:
+    driver: local
+
+networks:
+  esnet:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,43 +2,35 @@ version: '3.6'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0
-    container_name: elasticsearch
     environment:
       - cluster.name=cerebro-cluster
       - bootstrap.memory_lock=true
+      - "node.master=true"
+      - "xpack.monitoring.exporters.my_local_exporter.type=local"
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:
         soft: -1
         hard: -1
-    volumes:
-      - esdata1:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
     networks:
       - esnet
-  elasticsearch2:
+
+  elasticsearch_data:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.6.0
-    container_name: elasticsearch2
     environment:
       - cluster.name=cerebro-cluster
       - bootstrap.memory_lock=true
+      - "node.master=false"
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "discovery.zen.ping.unicast.hosts=elasticsearch"
     ulimits:
       memlock:
         soft: -1
         hard: -1
-    volumes:
-      - esdata2:/usr/share/elasticsearch/data
     networks:
       - esnet
-
-volumes:
-  esdata1:
-    driver: local
-  esdata2:
-    driver: local
 
 networks:
   esnet:


### PR DESCRIPTION
Adds Elastic Search to the project using `docker-compose` and adds rules to Makefile to use it.
Issue #2.

- `make es` should run docker-compose with the `docker-compose.yml` contained in root directory.
- `make es_logs` will output the docker-compose logs.
- `make es_down` will kill the Elastic Search cluster.